### PR TITLE
Remove opinionated airbnb extension

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,5 +1,4 @@
 {
-  "extends": "eslint-config-airbnb",
   "rules": {
     "semi": [2, "never"],
     "eqeqeq": [2, "smart"],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "peerDependencies": {
     "babel-eslint": "^6.0.3",
     "eslint": "^2.8.0",
-    "eslint-config-airbnb": "^8.0.0",
     "eslint-plugin-react": "^5.0.1"
   },
   "keywords": [


### PR DESCRIPTION
I don't see that jss _needs_ airbnb (I could be wrong).  Remove opinionated airbnb extension, it's transitive dependency tree is unnecessary and can be painful for those using other presets such as `standard`.

If a rule or rules are necessary from airbnb, we should add it them specifically so as to not cause pain to others that use presets such as `standard`.
